### PR TITLE
fix: add public base path

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -9,6 +9,7 @@ export default defineConfig((config) => {
   console.log(config)
 
   const viteConfig = {
+    base: './',
     resolve: {
       alias: {
         '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
Base is the public basic path for development or production environment services. It defaults to "/", is an absolute path, and is modified to "./" to be a relative path available for nginx proxy.