### PR TITLE
fix: #19 get export file whole url

### DIFF
--- a/src/utils/export-util.js
+++ b/src/utils/export-util.js
@@ -1,0 +1,13 @@
+import { VITE_APP_API } from '@/api/instance.js'
+
+/**
+ * 接口获取到的 url 为相对路径，需要拼接完整的页面路径
+ * https://github.com/mouday/domain-admin-web/issues/19
+ * @param {*} relativePathUrl 是接口返回的文件相对路径，一般为 res.data.url
+ * @returns 完整的 url
+ */
+export function getExportFileUrl(relativePathUrl) {
+  return process.env.NODE_ENV === 'development'
+    ? VITE_APP_API.replace('/api', relativePathUrl)
+    : `${window.location.href.split('/#/')[0]}${relativePathUrl}`
+}

--- a/src/views/domain-info-list/index.vue
+++ b/src/views/domain-info-list/index.vue
@@ -207,6 +207,7 @@ import { RoleEnum } from '@/emuns/role-enums.js'
 import { getTableColumn } from './table-column.js'
 import DataCount from '@/components/DataCount.vue'
 import ExportFileDialog from '@/components/export-file/ExportFileDialog.vue'
+import { getExportFileUrl } from '@/utils/export-util.js'
 
 export default {
   name: 'domain-list',
@@ -383,7 +384,7 @@ export default {
       })
 
       if (res.ok) {
-        FileSaver.saveAs(res.data.url, res.data.name)
+        FileSaver.saveAs(getExportFileUrl(res.data.url), res.data.name)
       }
     },
 

--- a/src/views/domain-list/index.vue
+++ b/src/views/domain-list/index.vue
@@ -201,6 +201,7 @@ import { RoleEnum } from '@/emuns/role-enums.js'
 import DataCount from '@/components/DataCount.vue'
 import ExportFileDialog from '@/components/export-file/ExportFileDialog.vue'
 import BatchUpdateForm from './BatchUpdateForm.vue'
+import { getExportFileUrl } from '@/utils/export-util.js'
 
 export default {
   name: 'domain-list',
@@ -380,7 +381,7 @@ export default {
       })
 
       if (res.ok) {
-        FileSaver.saveAs(res.data.url, res.data.name)
+        FileSaver.saveAs(getExportFileUrl(res.data.url), res.data.name)
       }
     },
 

--- a/src/views/monitor-list/index.vue
+++ b/src/views/monitor-list/index.vue
@@ -153,6 +153,7 @@ import ExportFileDialog from '@/components/export-file/ExportFileDialog.vue'
 import FileSaver from 'file-saver'
 import { genFileId } from 'element-plus'
 import dayjs from 'dayjs'
+import { getExportFileUrl } from '@/utils/export-util.js'
 
 export default {
   name: 'monitor-list',
@@ -287,7 +288,7 @@ export default {
       })
 
       if (res.ok) {
-        FileSaver.saveAs(res.data.url, res.data.name)
+        FileSaver.saveAs(getExportFileUrl(res.data.url), res.data.name)
       }
     },
 


### PR DESCRIPTION
1. #19 

### 变更
1. 新增 getExportFileUrl 方法，用来获取完整的导出文件下载地址
2. 本地开发时以接口请求地址进行裁剪
3. 部署后以实际访问地址进行裁剪

### 影响范围
- 兼容纯域名和域名后跟路径的情况
1. 证书管理 - 证书监控 - 导出
2. 域名监控 - 导出
3. 网站监控 - 导出

### 自测
通过 docker cp 的方式，把本地打包的文件替换了 docker 容器中的 public，验证通过。
- [x] 纯域名，如：https://my.baidu.com
- [x] 域名加路径，如：https://my.baidu.com/domain