### PR TITLE
feat: some optimize

### DIFF
--- a/src/views/domain-info-list/DataTable.vue
+++ b/src/views/domain-info-list/DataTable.vue
@@ -54,6 +54,20 @@
         align="center"
         width="100"
       >
+        <template #header>
+          <el-tooltip
+            effect="dark"
+            content="点击下方数字可前往证书监控页面查看详情"
+            placement="top-start"
+            :show-after="800"
+          >
+            <div class="inline-flex items-center">
+              <span class="mr-[2px]">{{ $t('证书数量') }}</span>
+              <el-icon><Warning /></el-icon>
+            </div>
+          </el-tooltip>
+        </template>
+
         <template #default="scope">
           <el-link
             v-if="scope.row.ssl_count && scope.row.ssl_count > 0"

--- a/src/views/domain-info-list/DataTable.vue
+++ b/src/views/domain-info-list/DataTable.vue
@@ -558,14 +558,12 @@ export default {
     },
 
     handleCertCountClick(row) {
-      let route = this.$router.resolve({
+      this.$router.push({
         name: 'cert-list',
         query: {
-          keyword: row.domain,
+          monitorId: row.domain,
         },
       })
-
-      window.open(route.href, '_blank')
     },
 
     handleRefreshRow(row) {

--- a/src/views/domain-list/index.vue
+++ b/src/views/domain-list/index.vue
@@ -508,6 +508,7 @@ export default {
       window.open(route.href, '_blank')
     },
 
+    // 暂未使用
     handleEditCert(row) {
       this.$router.push({
         name: 'CertEdit',

--- a/src/views/log-async-task-list/index.vue
+++ b/src/views/log-async-task-list/index.vue
@@ -22,7 +22,7 @@
           </template>
         </el-input>
     </div> -->
-    <div class="flex justify-between mb-sm">
+    <div class="flex justify-end mb-sm">
       <div></div>
 
       <el-popconfirm
@@ -38,8 +38,17 @@
           >
         </template>
       </el-popconfirm>
+
+      <el-link
+        :underline="false"
+        type="primary"
+        :disabled="loading"
+        @click="getData"
+      >
+        <el-icon><Refresh /></el-icon>{{ $t('刷新') }}
+      </el-link>
     </div>
-    
+
     <!-- 数据列表 -->
     <DataTable
       v-loading="loading"

--- a/src/views/log-monitor-list/index.vue
+++ b/src/views/log-monitor-list/index.vue
@@ -2,10 +2,10 @@
   <div class="app-container">
     <div class="flex justify-between mb-sm">
       <div class="flex items-center">
-        <span class="color--info">监控名称: </span>
-        <span class="ml-sm">{{ detail?.title }}</span>
+        <span class="color--info whitespace-nowrap">监控名称: </span>
+        <span class="ml-sm whitespace-nowrap">{{ detail?.title }}</span>
 
-        <span class="ml-md color--info">监控请求: </span>
+        <span class="ml-md color--info whitespace-nowrap">监控请求: </span>
         <span class="ml-sm">{{ detail?.content?.method }}</span>
         <el-link
           class="ml-sm"
@@ -13,14 +13,13 @@
           type="primary"
           :href="detail?.content?.url"
           :target="'_blank'"
-          >{{ detail?.content?.url }}</el-link
         >
+          <span class="check-url">{{ detail?.content?.url }}</span>
+        </el-link>
       </div>
 
       <div class="flex items-center">
-        <span class="color--info text-sm"
-          >下次运行时间：{{ detail?.next_run_time || '-'}}</span
-        >
+        <span class="color--info text-sm whitespace-nowrap">下次运行时间：{{ detail?.next_run_time || '-'}}</span>
 
         <el-link
           v-if="showMode == 'table'"
@@ -35,7 +34,7 @@
           v-else
           :underline="false"
           type="primary"
-          class="ml-sm"
+          class="ml-sm whitespace-nowrap"
           @click="handleChangeShowMode('table')"
           ><el-icon><Tickets /></el-icon>{{ $t('数据') }}</el-link
         >
@@ -48,7 +47,7 @@
             <el-link
               :underline="false"
               type="danger"
-              class="ml-sm"
+              class="ml-sm whitespace-nowrap"
               ><el-icon><Delete /></el-icon>{{ $t('清空日志') }}</el-link
             >
           </template>
@@ -278,4 +277,9 @@ export default {
 
 <style lang="less"></style>
 
-<style lang="less" scoped></style>
+<style lang="less" scoped>
+  .check-url {
+    max-width: calc(100vw - 1050px);
+    word-break: break-all;
+  }
+</style>

--- a/src/views/log-monitor-list/index.vue
+++ b/src/views/log-monitor-list/index.vue
@@ -53,6 +53,16 @@
             >
           </template>
         </el-popconfirm>
+
+        <el-link
+          :underline="false"
+          type="primary"
+          class="ml-sm whitespace-nowrap"
+          :disabled="loading"
+          @click="getData"
+        >
+          <el-icon><Refresh /></el-icon>{{ $t('刷新') }}
+        </el-link>
       </div>
     </div>
 

--- a/src/views/log-operation-list/index.vue
+++ b/src/views/log-operation-list/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="app-container">
-    <div class="flex justify-between mb-sm">
+    <div class="flex justify-end mb-sm">
       <div></div>
 
       <el-popconfirm
@@ -16,6 +16,15 @@
           >
         </template>
       </el-popconfirm>
+
+      <el-link
+        :underline="false"
+        type="primary"
+        :disabled="loading"
+        @click="getData"
+      >
+        <el-icon><Refresh /></el-icon>{{ $t('刷新') }}
+      </el-link>
     </div>
 
     <!-- 数据列表 -->

--- a/src/views/log-scheduler-list/index.vue
+++ b/src/views/log-scheduler-list/index.vue
@@ -22,7 +22,7 @@
           </template>
         </el-input>
     </div> -->
-    <div class="flex justify-between mb-sm">
+    <div class="flex justify-end mb-sm">
       <div></div>
 
       <el-popconfirm
@@ -38,6 +38,15 @@
           >
         </template>
       </el-popconfirm>
+
+      <el-link
+        :underline="false"
+        type="primary"
+        :disabled="loading"
+        @click="getData"
+      >
+        <el-icon><Refresh /></el-icon>{{ $t('刷新') }}
+      </el-link>
     </div>
 
     <!-- 数据列表 -->

--- a/src/views/monitor-list/DataTable.vue
+++ b/src/views/monitor-list/DataTable.vue
@@ -280,14 +280,12 @@ export default {
     },
 
     handleOpenLogClick(row) {
-      let route = this.$router.resolve({
+      this.$router.push({
         name: 'log-monitor-list',
         query: {
           monitorId: row.id,
         },
       })
-
-      window.open(route.href, '_blank')
     },
 
     handleSelectable(row, index) {

--- a/src/views/monitor-list/DataTable.vue
+++ b/src/views/monitor-list/DataTable.vue
@@ -85,6 +85,20 @@
         prop="status"
         width="100"
       >
+        <template #header>
+          <el-tooltip
+            effect="dark"
+            content="点击下方图标可前往监控日志页面查看详情"
+            placement="top-start"
+            :show-after="800"
+          >
+            <div class="inline-flex items-center">
+              <span class="mr-[2px]">{{ $t('状态') }}</span>
+              <el-icon><Warning /></el-icon>
+            </div>
+          </el-tooltip>
+        </template>
+
         <template #default="scope">
           <ConnectStatus
             :value="scope.row.status_value"
@@ -94,13 +108,26 @@
       </el-table-column>
 
       <el-table-column
-        
         :label="$t('日志')"
         header-align="center"
         align="center"
         prop="interval"
         width="100"
       >
+        <template #header>
+          <el-tooltip
+            effect="dark"
+            content="点击下方编号可前往监控日志页面查看详情"
+            placement="top-start"
+            :show-after="800"
+          >
+            <div class="inline-flex items-center">
+              <span class="mr-[2px]">{{ $t('日志') }}</span>
+              <el-icon><Warning /></el-icon>
+            </div>
+          </el-tooltip>
+        </template>
+
         <template #default="scope">
           <el-link
             v-if="scope.row.log_count && scope.row.log_count > 0"

--- a/src/views/notify-edit-webhook/DataForm.vue
+++ b/src/views/notify-edit-webhook/DataForm.vue
@@ -13,7 +13,7 @@
         <el-select
           v-model="form.method"
           placeholder="请求方法"
-          style="width: 100px"
+          style="width: 150px"
         >
           <el-option
             v-for="item in methodOptions"
@@ -81,6 +81,9 @@
         target="_blank"
         >微信推送消息通知接口汇总</a
       >
+    </div>
+    <div class="text-[14px] color--info">
+      <span>注意：测试时请保证已经添加数据且数据能触发通知</span>
     </div>
 
     <!-- 操作 -->

--- a/src/views/notify-edit/DataForm.vue
+++ b/src/views/notify-edit/DataForm.vue
@@ -47,8 +47,9 @@
         prop="event_id"
       >
         <el-select
-          :placeholder="$t('触发事件')"
-          v-model="form.event_id"
+        :placeholder="$t('触发事件')"
+        v-model="form.event_id"
+        style="width: 150px;"
         >
           <el-option
             v-for="item in EventOptions"
@@ -77,10 +78,10 @@
             :min="0"
             placeholder="剩余天数"
           ></el-input-number>
-          
+
           <div class="ml-sm text-sm color--info flex items-center">
             <el-icon><Warning /></el-icon>
-            <span>如果点击测试，收不到消息，请增加这个参数，例如：10000</span>
+            <span>点击测试收不到消息时，请增大这个参数，如：10000</span>
           </div>
         </el-form-item>
       </template>

--- a/src/views/notify-list/DataTable.vue
+++ b/src/views/notify-list/DataTable.vue
@@ -144,7 +144,7 @@
         <template #header>
           <el-tooltip
             effect="dark"
-            content="如果收不到消息，可尝试增加：剩余天数"
+            content="请添加真实数据后进行测试"
             placement="top-start"
             :show-after="800"
           >


### PR DESCRIPTION
### 变更
1. 四个日志页面添加刷新按钮
2. 网站监控 - 状态列、日志列，域名监控 - 证书数量列 添加了 tooltip；通知管理 - 测试列 tooltip 文案更新
3. 网站监控 - 状态列、日志列，域名监控 - 证书数量列 点击从新开页面改为当前页面打开新页面
4. 网站监控 - 日志详情，url 过长时的样式问题修复
5. 编辑通知的弹框样式修改及部分文案优化



### 相关截图
<img width="1470" alt="image" src="https://github.com/user-attachments/assets/cbb10655-cd86-4544-afff-2dd87ce2720c">
<img width="1035" alt="image" src="https://github.com/user-attachments/assets/3fe58fa1-14da-4b4d-b713-9a97b4167181">
<img width="1469" alt="image" src="https://github.com/user-attachments/assets/f02c8ea8-9a00-4564-befb-59bea559c5b2">
<img width="1434" alt="image" src="https://github.com/user-attachments/assets/4e9f7c13-5153-4ffa-9ebc-4f02c0bda8cc">
<img width="1469" alt="image" src="https://github.com/user-attachments/assets/0fad8dbe-01b7-4265-857e-20b57b9b108a">
<img width="807" alt="image" src="https://github.com/user-attachments/assets/f9016a46-3fef-45f5-971a-bda7dcd9ca5b">






