### PR TITLE
feat: implement dns-host association UI and auto-renew result display

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,23 @@
         "@codemirror/lang-json": "^6.0.1",
         "@codemirror/theme-one-dark": "^6.1.2",
         "@element-plus/icons-vue": "^2.1.0",
+        "@highlightjs/vue-plugin": "^2.1.0",
         "@ssddanbrown/codemirror-lang-twig": "^1.0.0",
         "axios": "^0.27.2",
         "codemirror": "^6.0.1",
+        "copy-to-clipboard": "^3.3.3",
+        "countup": "^1.8.2",
+        "countup.js": "^2.8.0",
+        "cron-parser": "^4.8.1",
+        "cron-validator": "^1.3.1",
         "dayjs": "^1.11.7",
+        "diff": "^5.1.0",
+        "echarts": "^5.4.3",
         "element-plus": "^2.3.6",
         "file-saver": "^2.0.5",
+        "highlight.js": "^11.8.0",
         "js-cookie": "^3.0.1",
+        "jszip": "^3.10.1",
         "lodash": "^4.17.21",
         "mockjs": "^1.1.0",
         "nprogress": "^0.2.0",
@@ -27,20 +37,16 @@
         "vue-router": "^4.2.2"
       },
       "devDependencies": {
-        "@more-copy/console-plugin": "^1.0.0",
-        "@more-copy/core": "^1.0.0",
-        "@more-copy/nunjucks-plugin": "^1.0.2",
-        "@more-copy/read-data-plugin": "^1.0.0",
-        "@more-copy/time-plugin": "^1.0.0",
-        "@vitejs/plugin-vue": "^3.1.0",
+        "@vitejs/plugin-vue": "^3.1.2",
         "autoprefixer": "^10.4.12",
+        "code-inspector-plugin": "^0.1.11",
         "less": "^4.1.3",
         "postcss": "^8.4.17",
         "rollup-plugin-visualizer": "^5.8.2",
         "tailwindcss": "^3.1.8",
         "unplugin-auto-import": "^0.11.2",
         "unplugin-vue-components": "^0.22.7",
-        "vite": "^3.1.0",
+        "vite": "^3.1.4",
         "vite-plugin-compression": "^0.5.1",
         "vite-plugin-style-import": "^2.0.0"
       }
@@ -234,6 +240,16 @@
         "@floating-ui/core": "^1.2.6"
       }
     },
+    "node_modules/@highlightjs/vue-plugin": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@highlightjs/vue-plugin/-/vue-plugin-2.1.0.tgz",
+      "integrity": "sha512-E+bmk4ncca+hBEYRV2a+1aIzIV0VSY/e5ArjpuSN9IO7wBJrzUE2u4ESCwrbQD7sAy+jWQjkV5qCCWgc+pu7CQ==",
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "highlight.js": "^11.0.1",
+        "vue": "^3"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
@@ -315,45 +331,6 @@
       "integrity": "sha512-IDhcWjfxwWACnatUi0GzWBCbochfqxo3LZZlS27LbJh8RVYYXXyR5Ck9659IhkWkhSW/kZlaaiJpUO+YZTUK+Q==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
-      }
-    },
-    "node_modules/@more-copy/console-plugin": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@more-copy/console-plugin/-/console-plugin-1.0.0.tgz",
-      "integrity": "sha512-tvMTtdgHvaFRH4/KbJLAieTrcdU8nNOKT47wUt4KUHNuxPP+d/O/4DId6jFFnQJJr9lzpbCB/eJtYHkOxcPfJw==",
-      "dev": true
-    },
-    "node_modules/@more-copy/core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@more-copy/core/-/core-1.0.0.tgz",
-      "integrity": "sha512-xOBmXfmVTm9AKN7GbEc3GrtHQfZBe414qzjs+an6ZRgRE8EuvnpLKLCUZbHh/ceBR2yXAroyuH0y0lOF/HMDyg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@more-copy/nunjucks-plugin": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@more-copy/nunjucks-plugin/-/nunjucks-plugin-1.0.2.tgz",
-      "integrity": "sha512-+oq4erFkrEc9b2YIXhd5ZGWcjcF1Tcq0OgqWh9wztZVrdT5XpQem2k9Upy/Ege3a2qyypzKmWpIsPML6/OCzyw==",
-      "dev": true,
-      "dependencies": {
-        "nunjucks": "^3.2.3"
-      }
-    },
-    "node_modules/@more-copy/read-data-plugin": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@more-copy/read-data-plugin/-/read-data-plugin-1.0.0.tgz",
-      "integrity": "sha512-YP931G2xtv6/Bg2UmsdWxhof0ydX3mvoHs8I0SqjIb0L7bu3HeGeJc9OH9yoz3MV0oBqItjH3QoDQxZEvBtiOg==",
-      "dev": true
-    },
-    "node_modules/@more-copy/time-plugin": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@more-copy/time-plugin/-/time-plugin-1.0.0.tgz",
-      "integrity": "sha512-CIj8mWB3yQShsnBqNflDMGIP0NPSJhnDDWrHa+Q3hI1r4tE8vX8kmEPRyZiyeW9ZMYk0DQZ0KFE433+4iUIMIA==",
-      "dev": true,
-      "dependencies": {
-        "dayjs": "^1.11.2"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -682,12 +659,6 @@
         }
       }
     },
-    "node_modules/a-sync-waterfall": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
-      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
-      "dev": true
-    },
     "node_modules/acorn": {
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
@@ -749,11 +720,12 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true
     },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "dev": true
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/async-validator": {
       "version": "4.2.5",
@@ -1015,6 +987,48 @@
         "node": ">=12"
       }
     },
+    "node_modules/code-inspector-core": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/code-inspector-core/-/code-inspector-core-0.1.13.tgz",
+      "integrity": "sha512-j/qTXq5Ktt3VpYgfRuO2t/CrekvkxGb7uegRpHtQGaVyoCVu1S66T7qYXBxRLHeqCcBe4+2kjv5yj/tvAPLkNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "^3.2.47",
+        "chalk": "^4.1.1",
+        "portfinder": "^1.0.28"
+      }
+    },
+    "node_modules/code-inspector-plugin": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/code-inspector-plugin/-/code-inspector-plugin-0.1.13.tgz",
+      "integrity": "sha512-H8AFrAE1M3d13kM60RMXwV0OnR9uo+Kn3VVZdZjniiYM13NSxVwN9ieaPkHjR+UHS/nkM5DEVsYPvghTja4Skw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "4.1.1",
+        "code-inspector-core": "0.1.13",
+        "vite-code-inspector-plugin": "0.1.13",
+        "webpack-code-inspector-plugin": "0.1.13"
+      }
+    },
+    "node_modules/code-inspector-plugin/node_modules/chalk": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
     "node_modules/codemirror": {
       "version": "6.0.1",
       "resolved": "https://registry.npmmirror.com/codemirror/-/codemirror-6.0.1.tgz",
@@ -1101,10 +1115,54 @@
         "url": "https://github.com/sponsors/mesqueeb"
       }
     },
+    "node_modules/copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "license": "MIT",
+      "dependencies": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/countup": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/countup/-/countup-1.8.2.tgz",
+      "integrity": "sha512-1qOuy+h+dgLY4TroLb4ZC2hK7HYS2Z7mnSUvdzoYAU7EZbqOse1mKZta/KYPhDPfd9lPDyP3Tb4pH6a10RkoCw=="
+    },
+    "node_modules/countup.js": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/countup.js/-/countup.js-2.9.0.tgz",
+      "integrity": "sha512-llqrvyXztRFPp6+i8jx25phHWcVWhrHO4Nlt0uAOSKHB8778zzQswa4MU3qKBvkXfJKftRYFJuVHez67lyKdHg==",
+      "license": "MIT"
+    },
     "node_modules/crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmmirror.com/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
+    },
+    "node_modules/cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/cron-validator": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/cron-validator/-/cron-validator-1.4.0.tgz",
+      "integrity": "sha512-wGcJ9FCy65iaU6egSH8b5dZYJF7GU/3Jh06wzaT9lsa5dbqExjljmu+0cJ8cpKn+vUyZa/EM4WAxeLR6SypJXw==",
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -1161,6 +1219,15 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true
     },
+    "node_modules/diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
@@ -1176,6 +1243,22 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
+    },
+    "node_modules/echarts": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
+      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "5.6.1"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.419",
@@ -1838,6 +1921,15 @@
         "tslib": "^2.0.3"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -1864,6 +1956,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1877,8 +1975,7 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -1976,6 +2073,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.18.2.tgz",
@@ -2011,6 +2114,18 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/less": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/less/-/less-4.1.3.tgz",
@@ -2035,6 +2150,15 @@
         "mime": "^1.4.1",
         "needle": "^3.1.0",
         "source-map": "~0.6.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lilconfig": {
@@ -2091,6 +2215,15 @@
       "dev": true,
       "dependencies": {
         "tslib": "^2.0.3"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {
@@ -2217,8 +2350,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "node_modules/mz": {
       "version": "2.7.0",
@@ -2310,40 +2442,6 @@
       "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
       "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA=="
     },
-    "node_modules/nunjucks": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
-      "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
-      "dev": true,
-      "dependencies": {
-        "a-sync-waterfall": "^1.0.0",
-        "asap": "^2.0.3",
-        "commander": "^5.1.0"
-      },
-      "bin": {
-        "nunjucks-precompile": "bin/precompile"
-      },
-      "engines": {
-        "node": ">= 6.9.0"
-      },
-      "peerDependencies": {
-        "chokidar": "^3.3.0"
-      },
-      "peerDependenciesMeta": {
-        "chokidar": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/nunjucks/node_modules/commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -2387,6 +2485,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/param-case": {
       "version": "3.0.4",
@@ -2545,6 +2649,38 @@
         "pathe": "^1.1.0"
       }
     },
+    "node_modules/portfinder": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
+      "integrity": "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.6",
+        "debug": "^4.3.6"
+      },
+      "engines": {
+        "node": ">= 10.12"
+      }
+    },
+    "node_modules/portfinder/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/postcss": {
       "version": "8.4.24",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
@@ -2675,6 +2811,12 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -2718,6 +2860,21 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/readdirp": {
@@ -2841,6 +2998,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2882,6 +3045,12 @@
         "upper-case-first": "^2.0.2"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
     "node_modules/snake-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
@@ -2916,6 +3085,15 @@
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead",
       "dev": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -3085,6 +3263,12 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ==",
+      "license": "MIT"
     },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
@@ -3324,8 +3508,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/vite": {
       "version": "3.2.7",
@@ -3374,6 +3557,16 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-code-inspector-plugin": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/vite-code-inspector-plugin/-/vite-code-inspector-plugin-0.1.13.tgz",
+      "integrity": "sha512-aKSumqqKcyav11uUgMEr/EAtAAn5e5XCnJnOYfy7zLaYjthMClSztHoi6b1PY5kL7e/SGj5hJSz0XDKAEzHeBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "code-inspector-core": "0.1.13"
       }
     },
     "node_modules/vite-plugin-compression": {
@@ -3505,6 +3698,16 @@
       "resolved": "https://registry.npmmirror.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     },
+    "node_modules/webpack-code-inspector-plugin": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/webpack-code-inspector-plugin/-/webpack-code-inspector-plugin-0.1.13.tgz",
+      "integrity": "sha512-+VxvQw7weufhBe3ehEX0lXgeEOwNlvZgWXDWgonn/54oBnB9b/3vrVcxD7KmXqDvklLoNRYY2cJPDN9fT4uvsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "code-inspector-core": "0.1.13"
+      }
+    },
     "node_modules/webpack-sources": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
@@ -3587,6 +3790,21 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/zrender": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
+      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     }
   },
   "dependencies": {
@@ -3735,6 +3953,12 @@
         "@floating-ui/core": "^1.2.6"
       }
     },
+    "@highlightjs/vue-plugin": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@highlightjs/vue-plugin/-/vue-plugin-2.1.0.tgz",
+      "integrity": "sha512-E+bmk4ncca+hBEYRV2a+1aIzIV0VSY/e5ArjpuSN9IO7wBJrzUE2u4ESCwrbQD7sAy+jWQjkV5qCCWgc+pu7CQ==",
+      "requires": {}
+    },
     "@jridgewell/gen-mapping": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
@@ -3809,42 +4033,6 @@
       "integrity": "sha512-IDhcWjfxwWACnatUi0GzWBCbochfqxo3LZZlS27LbJh8RVYYXXyR5Ck9659IhkWkhSW/kZlaaiJpUO+YZTUK+Q==",
       "requires": {
         "@lezer/common": "^1.0.0"
-      }
-    },
-    "@more-copy/console-plugin": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@more-copy/console-plugin/-/console-plugin-1.0.0.tgz",
-      "integrity": "sha512-tvMTtdgHvaFRH4/KbJLAieTrcdU8nNOKT47wUt4KUHNuxPP+d/O/4DId6jFFnQJJr9lzpbCB/eJtYHkOxcPfJw==",
-      "dev": true
-    },
-    "@more-copy/core": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@more-copy/core/-/core-1.0.0.tgz",
-      "integrity": "sha512-xOBmXfmVTm9AKN7GbEc3GrtHQfZBe414qzjs+an6ZRgRE8EuvnpLKLCUZbHh/ceBR2yXAroyuH0y0lOF/HMDyg==",
-      "dev": true
-    },
-    "@more-copy/nunjucks-plugin": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@more-copy/nunjucks-plugin/-/nunjucks-plugin-1.0.2.tgz",
-      "integrity": "sha512-+oq4erFkrEc9b2YIXhd5ZGWcjcF1Tcq0OgqWh9wztZVrdT5XpQem2k9Upy/Ege3a2qyypzKmWpIsPML6/OCzyw==",
-      "dev": true,
-      "requires": {
-        "nunjucks": "^3.2.3"
-      }
-    },
-    "@more-copy/read-data-plugin": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@more-copy/read-data-plugin/-/read-data-plugin-1.0.0.tgz",
-      "integrity": "sha512-YP931G2xtv6/Bg2UmsdWxhof0ydX3mvoHs8I0SqjIb0L7bu3HeGeJc9OH9yoz3MV0oBqItjH3QoDQxZEvBtiOg==",
-      "dev": true
-    },
-    "@more-copy/time-plugin": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@more-copy/time-plugin/-/time-plugin-1.0.0.tgz",
-      "integrity": "sha512-CIj8mWB3yQShsnBqNflDMGIP0NPSJhnDDWrHa+Q3hI1r4tE8vX8kmEPRyZiyeW9ZMYk0DQZ0KFE433+4iUIMIA==",
-      "dev": true,
-      "requires": {
-        "dayjs": "^1.11.2"
       }
     },
     "@nodelib/fs.scandir": {
@@ -4094,12 +4282,6 @@
         }
       }
     },
-    "a-sync-waterfall": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/a-sync-waterfall/-/a-sync-waterfall-1.0.1.tgz",
-      "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA==",
-      "dev": true
-    },
     "acorn": {
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
@@ -4143,10 +4325,10 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true
     },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+    "async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "dev": true
     },
     "async-validator": {
@@ -4326,6 +4508,41 @@
         "wrap-ansi": "^7.0.0"
       }
     },
+    "code-inspector-core": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/code-inspector-core/-/code-inspector-core-0.1.13.tgz",
+      "integrity": "sha512-j/qTXq5Ktt3VpYgfRuO2t/CrekvkxGb7uegRpHtQGaVyoCVu1S66T7qYXBxRLHeqCcBe4+2kjv5yj/tvAPLkNA==",
+      "dev": true,
+      "requires": {
+        "@vue/compiler-dom": "^3.2.47",
+        "chalk": "^4.1.1",
+        "portfinder": "^1.0.28"
+      }
+    },
+    "code-inspector-plugin": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/code-inspector-plugin/-/code-inspector-plugin-0.1.13.tgz",
+      "integrity": "sha512-H8AFrAE1M3d13kM60RMXwV0OnR9uo+Kn3VVZdZjniiYM13NSxVwN9ieaPkHjR+UHS/nkM5DEVsYPvghTja4Skw==",
+      "dev": true,
+      "requires": {
+        "chalk": "4.1.1",
+        "code-inspector-core": "0.1.13",
+        "vite-code-inspector-plugin": "0.1.13",
+        "webpack-code-inspector-plugin": "0.1.13"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
+          "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        }
+      }
+    },
     "codemirror": {
       "version": "6.0.1",
       "resolved": "https://registry.npmmirror.com/codemirror/-/codemirror-6.0.1.tgz",
@@ -4400,10 +4617,46 @@
         "is-what": "^3.14.1"
       }
     },
+    "copy-to-clipboard": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.3.tgz",
+      "integrity": "sha512-2KV8NhB5JqC3ky0r9PMCAZKbUHSwtEo4CwCs0KXgruG43gX5PMqDEBbVU4OUzw2MuAWUfsuFmWvEKG5QRfSnJA==",
+      "requires": {
+        "toggle-selection": "^1.0.6"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
+    "countup": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/countup/-/countup-1.8.2.tgz",
+      "integrity": "sha512-1qOuy+h+dgLY4TroLb4ZC2hK7HYS2Z7mnSUvdzoYAU7EZbqOse1mKZta/KYPhDPfd9lPDyP3Tb4pH6a10RkoCw=="
+    },
+    "countup.js": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/countup.js/-/countup.js-2.9.0.tgz",
+      "integrity": "sha512-llqrvyXztRFPp6+i8jx25phHWcVWhrHO4Nlt0uAOSKHB8778zzQswa4MU3qKBvkXfJKftRYFJuVHez67lyKdHg=="
+    },
     "crelt": {
       "version": "1.0.6",
       "resolved": "https://registry.npmmirror.com/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="
+    },
+    "cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "requires": {
+        "luxon": "^3.2.1"
+      }
+    },
+    "cron-validator": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/cron-validator/-/cron-validator-1.4.0.tgz",
+      "integrity": "sha512-wGcJ9FCy65iaU6egSH8b5dZYJF7GU/3Jh06wzaT9lsa5dbqExjljmu+0cJ8cpKn+vUyZa/EM4WAxeLR6SypJXw=="
     },
     "cssesc": {
       "version": "3.0.0",
@@ -4448,6 +4701,11 @@
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "dev": true
     },
+    "diff": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
+      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A=="
+    },
     "dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
@@ -4462,6 +4720,22 @@
       "requires": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
+      }
+    },
+    "echarts": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
+      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
+      "requires": {
+        "tslib": "2.3.0",
+        "zrender": "5.6.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
       }
     },
     "electron-to-chromium": {
@@ -4864,6 +5138,11 @@
         "tslib": "^2.0.3"
       }
     },
+    "highlight.js": {
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="
+    },
     "iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -4881,6 +5160,11 @@
       "dev": true,
       "optional": true
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4894,8 +5178,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -4963,6 +5246,11 @@
         "is-docker": "^2.0.0"
       }
     },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
     "jiti": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.18.2.tgz",
@@ -4990,6 +5278,17 @@
         "universalify": "^2.0.0"
       }
     },
+    "jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "requires": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "less": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/less/-/less-4.1.3.tgz",
@@ -5006,6 +5305,14 @@
         "parse-node-version": "^1.0.1",
         "source-map": "~0.6.0",
         "tslib": "^2.3.0"
+      }
+    },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "requires": {
+        "immediate": "~3.0.5"
       }
     },
     "lilconfig": {
@@ -5050,6 +5357,11 @@
       "requires": {
         "tslib": "^2.0.3"
       }
+    },
+    "luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew=="
     },
     "magic-string": {
       "version": "0.26.7",
@@ -5145,8 +5457,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "mz": {
       "version": "2.7.0",
@@ -5214,25 +5525,6 @@
       "resolved": "https://registry.npmjs.org/nprogress/-/nprogress-0.2.0.tgz",
       "integrity": "sha512-I19aIingLgR1fmhftnbWWO3dXc0hSxqHQHQb3H8m+K3TnEn/iSeTZZOyvKXWqQESMwuUVnatlCnZdLBZZt2VSA=="
     },
-    "nunjucks": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/nunjucks/-/nunjucks-3.2.4.tgz",
-      "integrity": "sha512-26XRV6BhkgK0VOxfbU5cQI+ICFUtMLixv1noZn1tGU38kQH5A5nmmbk/O45xdyBhD1esk47nKrY0mvQpZIhRjQ==",
-      "dev": true,
-      "requires": {
-        "a-sync-waterfall": "^1.0.0",
-        "asap": "^2.0.3",
-        "commander": "^5.1.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-          "dev": true
-        }
-      }
-    },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -5264,6 +5556,11 @@
         "is-docker": "^2.1.1",
         "is-wsl": "^2.2.0"
       }
+    },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "param-case": {
       "version": "3.0.4",
@@ -5371,6 +5668,27 @@
         "pathe": "^1.1.0"
       }
     },
+    "portfinder": {
+      "version": "1.0.38",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.38.tgz",
+      "integrity": "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg==",
+      "dev": true,
+      "requires": {
+        "async": "^3.2.6",
+        "debug": "^4.3.6"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+          "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        }
+      }
+    },
     "postcss": {
       "version": "8.4.24",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.24.tgz",
@@ -5436,6 +5754,11 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
@@ -5464,6 +5787,20 @@
           "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
           "dev": true
         }
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "readdirp": {
@@ -5536,6 +5873,11 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -5574,6 +5916,11 @@
         "upper-case-first": "^2.0.2"
       }
     },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
+    },
     "snake-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
@@ -5601,6 +5948,14 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "dev": true
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "string-width": {
       "version": "4.2.3",
@@ -5731,6 +6086,11 @@
       "requires": {
         "is-number": "^7.0.0"
       }
+    },
+    "toggle-selection": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "integrity": "sha512-BiZS+C1OS8g/q2RRbJmy59xpyghNBqrr6k5L/uKBGRsTfxmu3ffiRnd8mlGPUVayg8pvfi5urfnu8TU7DVOkLQ=="
     },
     "ts-interface-checker": {
       "version": "0.1.13",
@@ -5905,8 +6265,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "vite": {
       "version": "3.2.7",
@@ -5919,6 +6278,15 @@
         "postcss": "^8.4.18",
         "resolve": "^1.22.1",
         "rollup": "^2.79.1"
+      }
+    },
+    "vite-code-inspector-plugin": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/vite-code-inspector-plugin/-/vite-code-inspector-plugin-0.1.13.tgz",
+      "integrity": "sha512-aKSumqqKcyav11uUgMEr/EAtAAn5e5XCnJnOYfy7zLaYjthMClSztHoi6b1PY5kL7e/SGj5hJSz0XDKAEzHeBg==",
+      "dev": true,
+      "requires": {
+        "code-inspector-core": "0.1.13"
       }
     },
     "vite-plugin-compression": {
@@ -6027,6 +6395,15 @@
       "resolved": "https://registry.npmmirror.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
     },
+    "webpack-code-inspector-plugin": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/webpack-code-inspector-plugin/-/webpack-code-inspector-plugin-0.1.13.tgz",
+      "integrity": "sha512-+VxvQw7weufhBe3ehEX0lXgeEOwNlvZgWXDWgonn/54oBnB9b/3vrVcxD7KmXqDvklLoNRYY2cJPDN9fT4uvsw==",
+      "dev": true,
+      "requires": {
+        "code-inspector-core": "0.1.13"
+      }
+    },
     "webpack-sources": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
@@ -6088,6 +6465,21 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "dev": true
+    },
+    "zrender": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
+      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
+      "requires": {
+        "tslib": "2.3.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+          "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+        }
+      }
     }
   }
 }

--- a/src/components/remote-host/DataForm.vue
+++ b/src/components/remote-host/DataForm.vue
@@ -73,7 +73,6 @@
       </el-form-item>
 
       <!-- 密码 -->
-
       <el-form-item
         v-else
         label="密码"
@@ -86,6 +85,25 @@
           autocomplete="new-password"
           placeholder="请输入密码"
         ></el-input>
+      </el-form-item>
+
+      <!-- DNS -->
+      <el-form-item
+        label="关联DNS账号"
+        prop="dns_id"
+      >
+        <el-select
+          v-model="form.dns_id"
+          placeholder="请选择DNS账号"
+          clearable
+        >
+          <el-option
+            v-for="item in dnsList"
+            :key="item.id"
+            :label="item.name"
+            :value="item.id"
+          />
+        </el-select>
       </el-form-item>
     </el-form>
 
@@ -143,7 +161,9 @@ export default {
         auth_type: HostAuthTypeEnum.PASSWORD,
         password: '',
         private_key: '',
+        dns_id: 0,
       },
+      dnsList: [],
     }
   },
 
@@ -161,6 +181,15 @@ export default {
         }
       } else if (this.row && this.row.host) {
         this.form.host = this.row.host
+      }
+
+      this.getDnsList()
+    },
+
+    async getDnsList() {
+      const res = await this.$http.getDnsList()
+      if (res.code == 0) {
+        this.dnsList = res.data.list
       }
     },
 
@@ -200,6 +229,7 @@ export default {
         password: this.form.password,
         private_key: this.form.private_key,
         auth_type: this.form.auth_type,
+        dns_id: this.form.dns_id,
       }
 
       let res = null

--- a/src/views/issue-certificate-edit/VerifyStep.vue
+++ b/src/views/issue-certificate-edit/VerifyStep.vue
@@ -15,6 +15,7 @@
           :form="form"
           :list="fileList"
           @on-success="handleSuccess"
+          @on-tab-switch="handleTabSwitch"
         ></VerifyStepFile>
       </el-tab-pane>
       <el-tab-pane
@@ -142,6 +143,10 @@ export default {
 
     handleSuccess() {
       this.$emit('on-success')
+    },
+
+    handleTabSwitch(name) {
+      this.activeName = name
     },
   },
 

--- a/src/views/issue-certificate-edit/VerifyStepFile.vue
+++ b/src/views/issue-certificate-edit/VerifyStepFile.vue
@@ -36,6 +36,23 @@
       </el-form-item>
 
       <el-form-item
+        v-if="associatedDns"
+        label="关联DNS账号"
+      >
+        <el-tag type="success">{{ associatedDns.name }}</el-tag>
+        <el-button
+          class="ml-md"
+          link
+          type="primary"
+          @click="handleSwitchToDns"
+          >切换到 DNS 验证</el-button
+        >
+        <div class="color--info text-xs mt-xs">
+          此主机已关联 DNS 账号，您可以点击上方按钮或手动切换到 [DNS验证] 标签页进行一键配置。
+        </div>
+      </el-form-item>
+
+      <el-form-item
         :label="$t('服务器目录')"
         prop="verifyDeployPath"
       >
@@ -103,6 +120,7 @@ export default {
         deploy_host: null,
         verifyDeployPath: '',
       },
+      associatedDns: null,
 
       rules: {
         deploy_host: [
@@ -189,7 +207,29 @@ export default {
 
       if (res.data.list && res.data.list.length > 0) {
         this.deployForm.deploy_host = res.data.list[0]
+        this.handleChangeHost()
       }
+    },
+
+    async handleChangeHost() {
+      this.$refs.form.validateField(['deploy_host'])
+
+      if (this.deployForm.deploy_host && this.deployForm.deploy_host.dns_id) {
+        const res = await this.$http.getDnsById({
+          dns_id: this.deployForm.deploy_host.dns_id,
+        })
+        if (res.code == 0) {
+          this.associatedDns = res.data
+        } else {
+          this.associatedDns = null
+        }
+      } else {
+        this.associatedDns = null
+      }
+    },
+
+    handleSwitchToDns() {
+      this.$emit('on-tab-switch', 'dns')
     },
 
     async handleDeployVerifyCertificateById() {
@@ -276,9 +316,9 @@ export default {
       })
     },
 
-    handleChangeHost() {
-      this.$refs.form.validateField(['deploy_host'])
-    },
+    // handleChangeHost() {
+    //   this.$refs.form.validateField(['deploy_host'])
+    // },
   },
 
   created() {

--- a/src/views/issue-certificate-list/DataTable.vue
+++ b/src/views/issue-certificate-list/DataTable.vue
@@ -96,7 +96,22 @@
         </template>
       </el-table-column>
 
-      <!-- 创建时间 -->
+      <!-- 关联信息 -->
+      <el-table-column
+        :label="$t('关联信息')"
+        header-align="center"
+        align="center"
+        width="150"
+      >
+        <template #default="scope">
+          <div class="color--info text-xs">
+            <div>{{ $t('DNS账号') }}: {{ scope.row.challenge_deploy_name }}</div>
+            <div>{{ $t('部署主机') }}: {{ scope.row.deploy_host_name }}</div>
+          </div>
+        </template>
+      </el-table-column>
+
+      <!-- 更新时间 -->
       <el-table-column
         :label="$t('更新时间')"
         header-align="center"
@@ -151,6 +166,35 @@
             v-model="scope.row.is_auto_renew"
             @change="handleAutoRenewChange(scope.row, $event)"
           />
+
+          <!-- 续期结果 -->
+          <div
+            v-if="scope.row.is_auto_renew"
+            class="mt-xs text-xs"
+          >
+            <template v-if="scope.row.renew_status === 0">
+              <el-tag
+                size="small"
+                type="success"
+                >{{ $t('续期成功') }}</el-tag
+              >
+            </template>
+            <template v-else-if="scope.row.renew_status === 1">
+              <el-tooltip
+                class="box-item"
+                effect="dark"
+                :content="scope.row.renew_message"
+                placement="top"
+              >
+                <el-tag
+                  size="small"
+                  type="danger"
+                  class="cursor-pointer"
+                  >{{ $t('续期失败') }}</el-tag
+                >
+              </el-tooltip>
+            </template>
+          </div>
         </template>
       </el-table-column>
 


### PR DESCRIPTION
## 前端改动 (domain-admin-web)
1. 主机管理优化：
在“添加/编辑主机”表单中新增“关联 DNS 账号”下拉选框。
2. 证书申请流程联动：
在证书申请的“文件验证”步骤中，选择主机后会自动检测其关联的 DNS 账号，并提供“一键切换至 DNS 验证”的快捷入口。
3. 证书列表视觉增强：
新增“关联信息”列：以“DNS账号/部署主机”格式直观展示每条证书的去向。
续期结果可视化：在自动续期开关下方实时展示续期结果标签（成功/失败）。针对失败记录，支持鼠标悬停通过 Tooltip 查看具体错误日志。