### PR TITLE
fix: 补充英文翻译

### DIFF
--- a/src/i18n/config.js
+++ b/src/i18n/config.js
@@ -920,6 +920,11 @@ export default [
     'zh-TW': '編輯用戶',
   },
   {
+    'zh-CN': '证书管理',
+    'en-US': 'Cert Manage',
+    'zh-TW': '證書管理',
+  },
+  {
     'zh-CN': '证书监控',
     'en-US': 'Cert Monitor',
     'zh-TW': '證書監控',


### PR DESCRIPTION
补充了“证书管理”英文翻译
<img width="655" height="259" alt="fix_2026-05-07_17-31-10" src="https://github.com/user-attachments/assets/a5262b55-7a64-4407-8ae9-3ac4af76fa61" />
